### PR TITLE
vim-textobj-plugins無効

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -509,7 +509,7 @@ vnoremap <silent> <space>ud :call UrlEscapeTheSelectedTextLiteraly(2)<CR>
 "nnoremap ?  :set noincsearch<CR>?
 
 " textobj-datetimeの設定
-" silent! call textobj#datetime#default_mappings(1)
+silent! call textobj#datetime#default_mappings(1)
 
 "ScreenのキーバインドでC-Tを割り当てているため、タグジャンプの戻るはc-[に割り当てる。
 nnoremap <M-]> :pop<CR>
@@ -757,7 +757,7 @@ NeoBundle 'textobj-user'
 NeoBundle 'kana/vim-textobj-syntax.git'
 
 " vim-textobj-plugins : いろんなものをtext-objectにする
-NeoBundle 'thinca/vim-textobj-plugins.git'
+" NeoBundle 'thinca/vim-textobj-plugins.git'
 
 " vim-textobj-lastpat : 最後に検索されたパターンをtext-objectに
 NeoBundle 'kana/vim-textobj-lastpat.git'


### PR DESCRIPTION
以下のエラーが出るのでとりあえず無効

function textobj#user#plugin..26 の処理中にエラーが検出されました:
行   15:
E605: 例外が捕捉されませんでした: Unknown command: 'select-function'
function textobj#user#plugin の処理中にエラーが検出されました:
行   15:
E171: :endif がありません
続けるにはENTERを押すかコマンドを入力してください
