### PR TITLE
enable reattach-to-user-namespace MacOS

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -139,7 +139,7 @@ bind-key y copy-mode \; display "(Copy mode)"
 bind p paste-buffer
 
 # vでマーク開始
-set-option -g default-command "shell >/dev/null 2>&1; reattach-to-user-namespace -l zsh"
+if-shell "test expr '$OSTYPE' : 'darwin.*' > /dev/null" "set-option -g default-command 'reattach-to-user-namespace -l zsh'"
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 # yでヤンク + クリップボードへコピー
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"


### PR DESCRIPTION
Linuxで'reattach-to-user-namespace'部分がコケるのでmacのみ有効化