### PR TITLE
fix shell alias for linux

### DIFF
--- a/.profile
+++ b/.profile
@@ -29,10 +29,10 @@ TERM=xterm; export TERM
 #---------------------------------
 # alias
 #---------------------------------
-alias ls='ls -aG --color=auto'
-alias ll='ls -lGa'
-alias la="ls -GaF"
-alias lta="ls -GlthraF"
+alias ls='ls -a --color=auto'
+alias ll='ls -la'
+alias la="ls -aF"
+alias lta="ls -lthraF"
 #alias ls="ls -aFh --color=auto"
 #alias la='ls -alg --color=auto'
 #alias lh='ls -lh --color=auto'

--- a/.zshrc.alias
+++ b/.zshrc.alias
@@ -6,9 +6,9 @@
 # for fileutils (required yinst-ports/fileutils)
 ##---------------------------------
 # ls
-alias ls='ls -aGF'
-alias la='\ls -aGF'
-alias ll='ls -alGFthr'
+alias ls='ls -aF'
+alias la='\ls -aF'
+alias ll='ls -alFthr'
 #alias ls='ls -CF --color=auto --show-control-char'
 #alias ll='ls -alF --color=auto --show-control-char'
 alias rm 'rm -i'


### PR DESCRIPTION
linuxでのlsコマンドでオプションによってはファイルの所有グループが
見えなくなるのを修正