### PR TITLE
change path variable priority

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -2,15 +2,5 @@
 keychain --nogui --quiet ~/.ssh/id_rsa
 source ~/.keychain/$HOST-sh
 
-# anyenv
-if [ -d ${HOME}/.anyenv ] ; then
-  export PATH="$HOME/.anyenv/bin:$PATH"
-  eval "$(anyenv init - zsh)"
-  for D in `ls $HOME/.anyenv/envs`
-  do
-      export PATH="$HOME/.anyenv/envs/$D/shims:$PATH"
-  done
-fi
-
 # direnv
 eval "$(direnv hook zsh)"

--- a/.zshrc.osx
+++ b/.zshrc.osx
@@ -223,3 +223,14 @@ function peco-select-history() {
 }
 zle -N peco-select-history
 bindkey '^r' peco-select-history
+
+
+# anyenv
+if [ -d ${HOME}/.anyenv ] ; then
+  export PATH="$HOME/.anyenv/bin:$PATH"
+  eval "$(anyenv init - zsh)"
+  for D in `ls $HOME/.anyenv/envs`
+  do
+      export PATH="$HOME/.anyenv/envs/$D/shims:$PATH"
+  done
+fi


### PR DESCRIPTION
- pyenvでinstallしたpythonよりhomebrewでinstallしたpythonが優先されてしまう
- 環境変数PATHの優先順を変更